### PR TITLE
Trigger environments deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ script:
 after_success:
     - .scripts/travis/push-image.sh jats-ingester
 
+deploy:
+    provider: script
+    script: .scripts/travis/downstream.sh environments "Update jats-ingester to $TRAVIS_COMMIT"
+    on:
+        branch: master
+
 if: |
     branch = master OR \
     branch =~ /^(?:[0-9]|[1-9][0-9]*)\.(?:[0-9]|[1-9][0-9]*)$/ OR \


### PR DESCRIPTION
Completes https://github.com/libero/libero/issues/154 by triggering a build of `environments` whenever there is a new available version (i.e. tagged Docker image) of this project.

Added `TRAVIS_TOKEN` at https://travis-ci.com/libero/jats-ingester/settings