### PR TITLE
fix branching

### DIFF
--- a/dags/task_helpers.py
+++ b/dags/task_helpers.py
@@ -3,18 +3,18 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_previous_task_name(context):
+def get_previous_task_name(context: dict):
     if context['task'].upstream_list:
         return context['task'].upstream_list[0].task_id
     return None
 
 
-def get_return_value_from_previous_task(context):
-    previous_task = get_previous_task_name(context)
+def get_return_value_from_previous_task(context: dict, task_id: str = None):
+    previous_task = task_id if task_id else get_previous_task_name(context)
     return context['task_instance'].xcom_pull(task_ids=previous_task)
 
 
-def get_file_name_passed_to_dag_run_conf_file(context):
+def get_file_name_passed_to_dag_run_conf_file(context: dict):
     """
     Returns the value of the 'file' key in conf if it was supplied.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,38 @@ def context():
 
 
 @pytest.fixture
+def branched_context():
+    """
+    Generic Airflow context fixture with branched tasks that can be passed to a
+    callable that requires context
+    """
+    with create_session() as session:
+        dag = DAGFactory()
+
+        branched_previous_task = PythonOperatorFactory(task_id='branched_previous_task', dag=dag)
+        previous_task = PythonOperatorFactory(task_id='previous_task', dag=dag)
+        current_task = PythonOperatorFactory(task_id='current_task', dag=dag)
+        next_task = PythonOperatorFactory(task_id='next_task', dag=dag)
+
+        current_task.set_upstream(branched_previous_task)
+        current_task.set_upstream(previous_task)
+        current_task.set_downstream(next_task)
+
+        dag_run = dag.create_dagrun(
+            run_id="manual__",
+            start_date=timezone.utcnow(),
+            execution_date=timezone.utcnow(),
+            state=State.RUNNING,
+            conf=None,
+            session=session
+        )
+
+    ti = dag_run.get_task_instances()[1]
+    ti.task = current_task
+    return ti.get_template_context()
+
+
+@pytest.fixture
 def s3_client(mocker):
     """
     mocks boto client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,13 +69,14 @@ def branched_context():
     with create_session() as session:
         dag = DAGFactory()
 
-        branched_previous_task = PythonOperatorFactory(task_id='branched_previous_task', dag=dag)
-        previous_task = PythonOperatorFactory(task_id='previous_task', dag=dag)
+        branch_a = PythonOperatorFactory(task_id='branch_a', dag=dag)
+        branch_b = PythonOperatorFactory(task_id='branch_b', dag=dag)
         current_task = PythonOperatorFactory(task_id='current_task', dag=dag)
         next_task = PythonOperatorFactory(task_id='next_task', dag=dag)
 
-        current_task.set_upstream(branched_previous_task)
-        current_task.set_upstream(previous_task)
+        branch_a.set_downstream(current_task)
+        branch_b.set_downstream(current_task)
+        # join
         current_task.set_downstream(next_task)
 
         dag_run = dag.create_dagrun(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,12 @@
 
 
-def add_return_value_from_previous_task(return_value, context):
-    ti = context['dag_run'].get_task_instances()[0]
+def add_return_value_from_previous_task(return_value, context, task_id=None):
+    instances = context['dag_run'].get_task_instances()
+    ti = instances[0]  # fallback
+    for instance in instances:
+        if not task_id:
+            break
+        elif task_id in instance.task_id:
+            ti = instance
+            break
     ti.xcom_push(key='return_value', value=return_value)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,10 @@
 
 
-def add_return_value_from_previous_task(return_value, context, task_id=None):
+def populate_task_return_value(return_value, context, task_id=None):
+    """
+    Helper function for testing. Populates first task instance in list by
+    default (typically the previous task). Use task_id for deterministic results
+    """
     instances = context['dag_run'].get_task_instances()
     ti = instances[0]  # fallback
     for instance in instances:

--- a/tests/test_task_helpers.py
+++ b/tests/test_task_helpers.py
@@ -6,7 +6,7 @@ from dags.task_helpers import (
     get_file_name_passed_to_dag_run_conf_file
 )
 from tests.factories import TaskInstanceFactory
-from tests.helpers import add_return_value_from_previous_task
+from tests.helpers import populate_task_return_value
 
 
 def test_get_previous_task_name(context):
@@ -22,18 +22,19 @@ def test_get_previous_task_name_without_previous_task():
 
 def test_get_return_value_from_previous_task(context):
     expected = 'previous_return_value'
-    add_return_value_from_previous_task(expected, context)
+    populate_task_return_value(expected, context)
     result = get_return_value_from_previous_task(context)
     assert result == expected
 
 
 def test_get_return_value_from_branched_previous_task(branched_context):
-    expected = 'previous_return_value'
-    add_return_value_from_previous_task(expected, branched_context, task_id='branched_previous_task')
-    result = get_return_value_from_previous_task(branched_context, task_id='branched_previous_task')
+    expected = 'branch_a_return_value'
+    populate_task_return_value(expected, branched_context, task_id='branch_a')
+    result = get_return_value_from_previous_task(branched_context, task_id='branch_a')
     assert result == expected
 
-    result = get_return_value_from_previous_task(branched_context, task_id='previous_task')
+    # double checking the other task was not accidentally populated
+    result = get_return_value_from_previous_task(branched_context, task_id='branch_b')
     assert result is None
 
 

--- a/tests/test_task_helpers.py
+++ b/tests/test_task_helpers.py
@@ -6,6 +6,7 @@ from dags.task_helpers import (
     get_file_name_passed_to_dag_run_conf_file
 )
 from tests.factories import TaskInstanceFactory
+from tests.helpers import add_return_value_from_previous_task
 
 
 def test_get_previous_task_name(context):
@@ -21,9 +22,19 @@ def test_get_previous_task_name_without_previous_task():
 
 def test_get_return_value_from_previous_task(context):
     expected = 'previous_return_value'
-    context['task_instance'].xcom_pull = lambda **kwargs: expected
+    add_return_value_from_previous_task(expected, context)
     result = get_return_value_from_previous_task(context)
     assert result == expected
+
+
+def test_get_return_value_from_branched_previous_task(branched_context):
+    expected = 'previous_return_value'
+    add_return_value_from_previous_task(expected, branched_context, task_id='branched_previous_task')
+    result = get_return_value_from_previous_task(branched_context, task_id='branched_previous_task')
+    assert result == expected
+
+    result = get_return_value_from_previous_task(branched_context, task_id='previous_task')
+    assert result is None
 
 
 def test_get_return_value_from_previous_task_without_return_value():


### PR DESCRIPTION
Before sending an article to the content store, the article is retrieved from the previous task. Since introducing branching, the task to retrieve the article from is now indeterministic. This PR adds a method to specify which upstream task to retrieve the article from.