### PR TITLE
add clairvoyant airflow maintenance dags to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,9 @@ COPY ./dags ${AIRFLOW_HOME}/dags
 
 # add maintenance dags
 ADD https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/clear-missing-dags/airflow-clear-missing-dags.py \
-    ${AIRFLOW_HOME}/dags/maintenance-dags/airflow-clear-missing-dags.py
-ADD https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/db-cleanup/airflow-db-cleanup.py \
-    ${AIRFLOW_HOME}/dags/maintenance-dags/airflow-db-cleanup.py
-ADD https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/kill-halted-tasks/airflow-kill-halted-tasks.py \
-    ${AIRFLOW_HOME}/dags/maintenance-dags/airflow-kill-halted-tasks.py
+    https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/db-cleanup/airflow-db-cleanup.py \
+    https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/kill-halted-tasks/airflow-kill-halted-tasks.py \
+    ${AIRFLOW_HOME}/dags/maintenance-dags/
 
 COPY scripts/ scripts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,15 @@ RUN pip install -U pip \
     && rm -rf /tmp/*
 
 COPY ./dags ${AIRFLOW_HOME}/dags
+
+# add maintenance dags
+ADD https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/clear-missing-dags/airflow-clear-missing-dags.py \
+    ${AIRFLOW_HOME}/dags/maintenance-dags/airflow-clear-missing-dags.py
+ADD https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/db-cleanup/airflow-db-cleanup.py \
+    ${AIRFLOW_HOME}/dags/maintenance-dags/airflow-db-cleanup.py
+ADD https://raw.githubusercontent.com/teamclairvoyant/airflow-maintenance-dags/master/kill-halted-tasks/airflow-kill-halted-tasks.py \
+    ${AIRFLOW_HOME}/dags/maintenance-dags/airflow-kill-halted-tasks.py
+
 COPY scripts/ scripts/
 
 RUN chown -R airflow: .


### PR DESCRIPTION
In reference to https://github.com/libero/publisher/issues/247

Downloads relevant [maintenance DAGs by teamclairvoyant](https://github.com/teamclairvoyant/airflow-maintenance-dags) and adds them to the `dags` directory under the directory `maintenance-dags`.