### PR TITLE
replace requests-mock with responses library

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,4 +4,4 @@ pytest==4.5.0
 pytest-clarity==0.1.0a1
 pytest-mock==1.10.4
 pytest-socket==0.3.3
-requests-mock==1.6.0
+responses==0.10.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import socket
 
 import pytest
+import responses
 from airflow.utils import timezone
 from airflow.utils.db import create_session
 from airflow.utils.state import State
@@ -121,3 +122,9 @@ def set_remote_logs_env_var():
     os.environ['AIRFLOW_CONN_REMOTE_LOGS'] = 'test-uri?host=http://test-host:1234'
     yield
     del os.environ['AIRFLOW_CONN_REMOTE_LOGS']
+
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as response:
+        yield response

--- a/tests/test_process_zip_dag.py
+++ b/tests/test_process_zip_dag.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from zipfile import ZipFile
 
 import pytest
+import responses
 from lxml import etree
 from requests.exceptions import HTTPError
 
@@ -311,38 +312,40 @@ def test_wrap_article_in_libero_xml_raises_exception_if_xml_path_not_returned_by
     ('libero-00666.xml', '00666'),  # elife
     ('libero-685172.xml', '685172')  # biorxiv
 ])
-def test_send_article_to_service(xml_file, article_id, context, requests_mock):
+def test_send_article_to_service(xml_file, article_id, context, mocked_responses):
     # setup
     test_asset_path = str(get_asset(xml_file).absolute())
     article_xml = etree.tostring(etree.parse(test_asset_path), xml_declaration=True, encoding='UTF-8')
     populate_task_return_value(return_value=article_xml, context=context)
-    session = requests_mock.put('http://test-service.org/items/%s/versions/1' % article_id)
+    mocked_responses.add(responses.PUT, 'http://test-service.org/items/%s/versions/1' % article_id)
 
     # test
     pezd.send_article_to_content_service(**context)
-    response = session._responses[0].get_response(session.last_request)
+    response = mocked_responses.calls[-1].response
     assert response.status_code == 200
-    request_data = bytes(session.last_request.text, encoding='UTF-8')
+    
+    request_data = mocked_responses.calls[-1].request.body
     etree.parse(BytesIO(request_data))  # raises exception if cannot parse xml
 
 
-def test_send_article_to_service_raises_exception_for_non_200_response_code(context, requests_mock):
+def test_send_article_to_service_raises_exception_for_non_200_response_code(context, mocked_responses):
     # setup
     test_asset_path = str(get_asset('libero-00666.xml').absolute())
     article_xml = etree.tostring(etree.parse(test_asset_path), xml_declaration=True, encoding='UTF-8')
     populate_task_return_value(return_value=article_xml, context=context)
-    requests_mock.put(
+    mocked_responses.add(
+        responses.PUT,
         'http://test-service.org/items/00666/versions/1',
-        status_code=400,
-        text=('<?xml version="1.0" encoding="UTF-8"?>'
-              '<problem xmlns="urn:ietf:rfc:7807" xml:lang="en">'
-              '  <status>400</status>'
-              '  <title>Failed to load asset</title>'
-              '  <details>Failed to load https://unstable-jats-ingester-expanded.'
-              '  s3.amazonaws.com/elife-00666-vor-r1/10.7554/eLife.00666.004 '
-              '  due to "404 Not Found".'
-              '  </details>'
-              '</problem>')
+        status=400,
+        body=(b'<?xml version="1.0" encoding="UTF-8"?>'
+              b'<problem xmlns="urn:ietf:rfc:7807" xml:lang="en">'
+              b'  <status>400</status>'
+              b'  <title>Failed to load asset</title>'
+              b'  <details>Failed to load https://unstable-jats-ingester-expanded.'
+              b'  s3.amazonaws.com/elife-00666-vor-r1/10.7554/eLife.00666.004 '
+              b'  due to "404 Not Found".'
+              b'  </details>'
+              b'</problem>')
     )
 
     with pytest.raises(HTTPError):


### PR DESCRIPTION
I encountered an issue serialising and deserialising python objects to json using `requests-mock`. This library is maintained by the Sentry team and **seems** a little more robust.

- replace `requests-mock` with `responses` library for mocking request responses