### PR TITLE
send put request to details service

### DIFF
--- a/config/airflow.dev.cfg
+++ b/config/airflow.dev.cfg
@@ -23,6 +23,9 @@ search_url = http://search:8099/reindex
 # number of thread pool workers
 thread_pool_workers =
 
+# url to send details about scholarly content e.g. research articles
+details_service_url = http://scholarly-content-detail
+
 [core]
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository

--- a/config/airflow.test.cfg
+++ b/config/airflow.test.cfg
@@ -23,6 +23,9 @@ search_url = http://test-search.org/reindex
 # number of thread pool workers
 thread_pool_workers =
 
+# url to send details about scholarly content e.g. research articles
+details_service_url = http://test-details-service
+
 [core]
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository

--- a/dags/process_zip_dag.py
+++ b/dags/process_zip_dag.py
@@ -238,7 +238,7 @@ def send_article_info_to_details_service(**context) -> bytes:
     category_ids = []
     for category in categories_in_xml:
         response = requests.get(
-            '%s/catgories?name=%s' % (DETAILS_SERVICE_URL, quote_plus(category))
+            '%s/categories?name=%s' % (DETAILS_SERVICE_URL, quote_plus(category))
         )
         response.raise_for_status()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,5 +126,5 @@ def set_remote_logs_env_var():
 
 @pytest.fixture
 def mocked_responses():
-    with responses.RequestsMock() as response:
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as response:
         yield response

--- a/tests/test_process_zip_dag.py
+++ b/tests/test_process_zip_dag.py
@@ -283,13 +283,13 @@ def test_send_article_info_to_details_service(xml_file, article_id, category_ids
 
     successful_response_obj = {'items': [{'id': '0', 'name': 'Category 0'}]}
     mocked_responses.add(responses.GET,
-                         'http://test-details-service/catgories?name=Research+Article',
+                         'http://test-details-service/categories?name=Research+Article',
                          json=successful_response_obj)
     mocked_responses.add(responses.GET,
-                         'http://test-details-service/catgories?name=Regular+Article',
+                         'http://test-details-service/categories?name=Regular+Article',
                          json=successful_response_obj)
     mocked_responses.add(responses.GET,
-                         'http://test-details-service/catgories?name=Genetics',
+                         'http://test-details-service/categories?name=Genetics',
                          json={'items': []})
     mocked_responses.add(responses.POST,
                          'http://test-details-service/categories',


### PR DESCRIPTION
In reference to https://github.com/libero/publisher/issues/245

Adds a new task in `process_zip_dag.py` that compares categories found in the JATS xml to those in the details service. If a category is not found then it is added to the details service. Finally, the details service article resource is updated relating the relevant category ids.