### PR TITLE
Upgrade docker-compose version to fix container names bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: minimal
 
 services: docker
 
-addons:
-    apt:
-        packages:
-            - docker-compose
-
-
 env:
     global:
         # hyphen in project names are stripped away in Travis's CI old docker-compose version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: minimal
 
 services: docker
 
+addons:
+    apt:
+        packages:
+            - docker-compose
+
+
 env:
     global:
         # hyphen in project names are stripped away in Travis's CI old docker-compose version

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ env:
         - COMPOSE_PROJECT_NAME=jatsingester
         - IMAGE_REVISION=$TRAVIS_COMMIT
         - IMAGE_TAG=$TRAVIS_COMMIT
+        - DOCKER_COMPOSE_VERSION=1.24.1
+
+before_install:
+    - sudo rm /usr/local/bin/docker-compose
+    - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    - chmod +x docker-compose
+    - sudo mv docker-compose /usr/local/bin
 
 install:
     - docker-compose version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
         - IMAGE_TAG=$TRAVIS_COMMIT
 
 install:
+    - docker-compose version
     - travis_retry docker-compose build
 
 script:


### PR DESCRIPTION
Suspected to be a problematic version.

[`docker-compose` 1.23.2 CHANGELOG](https://github.com/docker/compose/blob/master/CHANGELOG.md#1232-2018-11-28):

> Reverted a 1.23.0 change that appended random strings to container names created by docker-compose up, causing addressability issues. Note: Containers created by docker-compose run will continue to use randomly generated names to avoid collisions during parallel runs.

See also https://github.com/libero/jats-ingester/pull/55#issuecomment-539535880