### PR TITLE
Create empty .aws folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV AIRFLOW_HOME=/airflow
 ENV AWS_SDK_LOAD_CONFIG=true
 
 WORKDIR ${AIRFLOW_HOME}
+RUN mkdir .aws
 
 COPY python-requirements/ python-requirements/
 COPY node-dependencies/* ./


### PR DESCRIPTION
If we don't have one, a `root`-owned one gets created while [mounting the volume for `.aws/config`](https://github.com/libero/sample-configuration/pull/83)