### PR TITLE
change airflow admin ui navbar color for local devs

### DIFF
--- a/config/airflow.dev.cfg
+++ b/config/airflow.dev.cfg
@@ -310,7 +310,7 @@ page_size = 100
 rbac = False
 
 # Define the color of navigation bar
-navbar_color = #007A87
+navbar_color = #0F52BA
 
 # Default dagrun to show in UI
 default_dag_run_display_number = 25


### PR DESCRIPTION
This is useful to distinguish when you have the live environment Airflow Admin UI open in a browser tab along side the local dev.