### PR TITLE
Do not add JATS namespace to elements that already have a different one

### DIFF
--- a/dags/js/tasks/wrap-article-in-libero-xml.js
+++ b/dags/js/tasks/wrap-article-in-libero-xml.js
@@ -19,10 +19,16 @@ function wrapArticleInLiberoXML(xmlStringBuffer) {
   xmlDoc.root().attr('xml:base', base);
 
   function addJATSPrefix(element) {
-    element.name('jats:' + element.name());
-    element.childNodes().forEach((child) => {
-      addJATSPrefix(child);
-    })
+    const isAJatsElementWithoutAnExplicitNamespace = !element.namespace();
+    if (isAJatsElementWithoutAnExplicitNamespace) {
+      // can't find a way to make element.namespace(ns_object) work
+      //element.namespace(jatsNamespace);
+      element.name('jats:'+element.name());
+
+      element.childNodes().forEach((child) => {
+        addJATSPrefix(child);
+      })
+    }
   }
 
   addJATSPrefix(xmlDoc.root());

--- a/tests/js/unit/wrap-article-in-libero-xml.test.js
+++ b/tests/js/unit/wrap-article-in-libero-xml.test.js
@@ -18,6 +18,9 @@ test('wrap article xml with libero xml using elife zip', () => {
                      '<front>' +
                        '<article-meta>' +
                          '<article-id pub-id-type="publisher-id">00666</article-id>' +
+                         '<permissions>' +
+                           '<ali:free_to_read/>' +
+                         '</permissions>' +
                        '</article-meta>' +
                      '</front>' +
                    '</article>';
@@ -37,6 +40,9 @@ test('wrap article xml with libero xml using elife zip', () => {
                       '<jats:front>' +
                         '<jats:article-meta>' +
                           '<jats:article-id pub-id-type="publisher-id">00666</jats:article-id>' +
+                          '<jats:permissions>' +
+                            '<ali:free_to_read/>' +
+                          '</jats:permissions>' +
                         '</jats:article-meta>' +
                       '</jats:front>' +
                     '</jats:article>' +


### PR DESCRIPTION
Elements start without a namespace (for some reason) so we add that JATS namespace to all of them. However, some elements may belong to a different namespace like the [Access License and Indicators one](https://jats.nlm.nih.gov/publishing/tag-library/1.2d1/attribute/xmlns-ali.html) so that doesn't apply to them.

See https://github.com/libero/publisher/issues/295#issuecomment-553848190 where an incorrect element is produced named `<ali:jats:free_to_read/>`.